### PR TITLE
Add useRealServices environment flag

### DIFF
--- a/src/app/bookings-v3/services/service.factory.ts
+++ b/src/app/bookings-v3/services/service.factory.ts
@@ -1,0 +1,17 @@
+import { inject, InjectionToken } from '@angular/core';
+import { environment } from '../../../environments/environment';
+
+import { SmartBookingService } from './smart-booking.service';
+import { SmartBookingServiceMock } from './mock/smart-booking.service.mock';
+
+export const SMART_BOOKING_SERVICE = new InjectionToken<SmartBookingService>('SmartBookingService');
+
+export function smartBookingServiceFactory() {
+  return environment.useRealServices ?
+    inject(SmartBookingService) :
+    inject(SmartBookingServiceMock);
+}
+
+export const BOOKING_V3_PROVIDERS = [
+  { provide: SMART_BOOKING_SERVICE, useFactory: smartBookingServiceFactory }
+];

--- a/src/environments/environment.dev.ts
+++ b/src/environments/environment.dev.ts
@@ -1,5 +1,6 @@
 export const environment = {
   production: false,
+  useRealServices: false,
   // Your web app's Firebase configuration
   // For Firebase JS SDK v7.20.0 and later, measurementId is optional
   baseUrl: 'https://dev.api.boukii.com/api',

--- a/src/environments/environment.local.ts
+++ b/src/environments/environment.local.ts
@@ -1,5 +1,6 @@
 export const environment = {
   production: false,
+  useRealServices: true,
   // Your web app's Firebase configuration
   // For Firebase JS SDK v7.20.0 and later, measurementId is optional
   baseUrl: 'http://api-boukii.test/api',

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,5 +1,6 @@
 export const environment = {
   production: true,
+  useRealServices: true,
   // Your web app's Firebase configuration
   // For Firebase JS SDK v7.20.0 and later, measurementId is optional
   baseUrl: 'https://api.boukii.com/api',

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -4,6 +4,7 @@
 
 export const environment = {
   production: false,
+  useRealServices: false,
   // Your web app's Firebase configuration
   // For Firebase JS SDK v7.20.0 and later, measurementId is optional
   baseUrl: 'https://dev.api.boukii.com/api',


### PR DESCRIPTION
## Summary
- configure environment files with `useRealServices`
- add a booking service factory that reads the flag

## Testing
- `npm test` *(fails: cannot find module `karma-coverage-istanbul-reporter`)*

------
https://chatgpt.com/codex/tasks/task_e_68834ec6b2dc832092a91be681e71358