### PR TITLE
Add booking modals and wizard edit support

### DIFF
--- a/src/app/bookings-v3/components/skipro-cancelar-reserva/skipro-cancelar-reserva.component.ts
+++ b/src/app/bookings-v3/components/skipro-cancelar-reserva/skipro-cancelar-reserva.component.ts
@@ -1,0 +1,32 @@
+import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { SkiProBooking } from '../../interfaces/skipro.interfaces';
+
+@Component({
+  selector: 'app-skipro-cancelar-reserva',
+  template: `
+    <div class="bg-white rounded-lg shadow-xl w-full max-w-sm overflow-hidden">
+      <div class="px-4 py-2 border-b flex justify-between items-center">
+        <h2 class="text-lg font-semibold">Cancelar Reserva</h2>
+        <button mat-icon-button (click)="cerrar.emit()">
+          <mat-icon>close</mat-icon>
+        </button>
+      </div>
+      <div class="p-4 text-sm">
+        <p>¿Seguro que deseas cancelar la reserva {{ reserva?.id }} para {{ reserva?.cliente.nombre }} {{ reserva?.cliente.apellido }}?</p>
+      </div>
+      <div class="px-4 py-2 border-t flex justify-end gap-2">
+        <button mat-button (click)="cerrar.emit()">No</button>
+        <button mat-raised-button color="warn" (click)="confirmar()">Sí, cancelar</button>
+      </div>
+    </div>
+  `
+})
+export class SkiProCancelarReservaComponent {
+  @Input() reserva: SkiProBooking | null = null;
+  @Output() cancelar = new EventEmitter<void>();
+  @Output() cerrar = new EventEmitter<void>();
+
+  confirmar() {
+    this.cancelar.emit();
+  }
+}

--- a/src/app/bookings-v3/components/skipro-reserva-detalles/skipro-reserva-detalles.component.ts
+++ b/src/app/bookings-v3/components/skipro-reserva-detalles/skipro-reserva-detalles.component.ts
@@ -1,0 +1,31 @@
+import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { SkiProBooking } from '../../interfaces/skipro.interfaces';
+
+@Component({
+  selector: 'app-skipro-reserva-detalles',
+  template: `
+    <div class="bg-white rounded-lg shadow-xl w-full max-w-lg overflow-hidden">
+      <div class="px-4 py-2 border-b flex justify-between items-center">
+        <h2 class="text-lg font-semibold">Detalle Reserva {{ reserva?.id }}</h2>
+        <button mat-icon-button (click)="cerrar.emit()">
+          <mat-icon>close</mat-icon>
+        </button>
+      </div>
+      <div class="p-4 space-y-2 text-sm">
+        <div><span class="font-medium">Cliente:</span> {{ reserva?.cliente.nombre }} {{ reserva?.cliente.apellido }}</div>
+        <div><span class="font-medium">Tipo:</span> {{ reserva?.tipo }}</div>
+        <div><span class="font-medium">Elemento:</span> {{ reserva?.reserva.nombre }}</div>
+        <div><span class="font-medium">Fechas:</span> {{ reserva?.fechas.display }}</div>
+        <div><span class="font-medium">Estado:</span> {{ reserva?.estado }}</div>
+        <div><span class="font-medium">Precio:</span> {{ reserva?.precio }} {{ reserva?.moneda }}</div>
+      </div>
+      <div class="px-4 py-2 border-t flex justify-end">
+        <button mat-button (click)="cerrar.emit()">Cerrar</button>
+      </div>
+    </div>
+  `
+})
+export class SkiProReservaDetallesComponent {
+  @Input() reserva: SkiProBooking | null = null;
+  @Output() cerrar = new EventEmitter<void>();
+}

--- a/src/app/bookings-v3/components/skipro-wizard-inline/skipro-wizard-inline.component.ts
+++ b/src/app/bookings-v3/components/skipro-wizard-inline/skipro-wizard-inline.component.ts
@@ -742,6 +742,7 @@ import {
 })
 export class SkiProWizardInlineComponent implements OnInit {
 
+  @Input() clientePreseleccionado: SkiProCliente | null = null;
   @Output() cerrar = new EventEmitter<void>();
   @Output() reservaCreada = new EventEmitter<SkiProBooking>();
 
@@ -832,6 +833,13 @@ export class SkiProWizardInlineComponent implements OnInit {
 
       // Cargar datos V3 adicionales
       await this.cargarDatosV3();
+
+      if (this.clientePreseleccionado) {
+        const pre = clientes?.find(c => c.id === this.clientePreseleccionado!.id);
+        if (pre) {
+          this.seleccionarCliente(pre);
+        }
+      }
 
       console.log('🧙‍♂️ SkiPro Wizard Inline loaded');
     } catch (error) {

--- a/src/app/bookings-v3/components/skipro-wizard/skipro-wizard.component.ts
+++ b/src/app/bookings-v3/components/skipro-wizard/skipro-wizard.component.ts
@@ -21,7 +21,7 @@ import {
           <div class="flex items-center gap-3">
             <mat-icon class="text-2xl">{{ getStepIcon() }}</mat-icon>
             <div>
-              <h2 class="text-xl font-semibold">Nueva Reserva</h2>
+              <h2 class="text-xl font-semibold">{{ editMode ? 'Editar Reserva' : 'Nueva Reserva' }}</h2>
               <p class="text-sm text-secondary">{{ getStepDescription() }}</p>
             </div>
           </div>
@@ -338,6 +338,7 @@ export class SkiProWizardComponent implements OnInit {
     puntoEncuentro: ''
   });
   public procesandoReserva = signal(false);
+  public editMode = false;
 
   // Forms
   public nuevoClienteForm = {
@@ -368,6 +369,31 @@ export class SkiProWizardComponent implements OnInit {
       this.clientesDisponibles.set(clientes || []);
       this.tiposReserva.set(tipos || []);
       this.cursosDisponibles.set(cursos || []);
+
+      const clienteId = this.route.snapshot.queryParamMap.get('clienteId');
+      if (clienteId) {
+        const pre = clientes?.find(c => String(c.id) === clienteId);
+        if (pre) {
+          this.seleccionarCliente(pre);
+        }
+      }
+
+      const reservaId = this.route.snapshot.paramMap.get('reservaId');
+      if (reservaId) {
+        const reserva = await this.skipro.getReservaPorId(reservaId).toPromise();
+        if (reserva) {
+          const cli = clientes?.find(c => c.email === reserva.cliente.email);
+          const tipo = tipos?.find(t => t.nombre === reserva.tipo);
+          const curso = cursos?.find(c => c.nombre === reserva.reserva.nombre);
+          this.wizardState.update(state => ({
+            ...state,
+            cliente: cli || state.cliente,
+            tipoReserva: tipo,
+            cursoSeleccionado: curso
+          }));
+          this.editMode = true;
+        }
+      }
 
       console.log('🧙‍♂️ SkiPro Wizard loaded');
     } catch (error) {

--- a/src/app/bookings-v3/services/mock/skipro-mock-data.service.ts
+++ b/src/app/bookings-v3/services/mock/skipro-mock-data.service.ts
@@ -390,6 +390,22 @@ export class SkiProMockDataService {
   }
 
   /**
+   * Obtener reserva por ID
+   */
+  getReservaPorId(id: string): Observable<SkiProBooking | null> {
+    const reserva = this.getMockReservas().find(r => r.id === id) || null;
+    return of(reserva).pipe(delay(200));
+  }
+
+  /**
+   * Cancelar reserva
+   */
+  cancelarReserva(id: string): Observable<boolean> {
+    console.log('❌ [SKIPRO] Cancelando reserva:', id);
+    return of(true).pipe(delay(500));
+  }
+
+  /**
    * Buscar clientes
    */
   buscarClientes(query: string): Observable<SkiProCliente[]> {

--- a/src/app/bookings-v3/skipro.module.ts
+++ b/src/app/bookings-v3/skipro.module.ts
@@ -29,6 +29,8 @@ import { SkiProWizardComponent } from './components/skipro-wizard/skipro-wizard.
 import { SkiProClientePerfilComponent } from './components/skipro-cliente-perfil/skipro-cliente-perfil.component';
 import { SkiProWizardInlineComponent } from './components/skipro-wizard-inline/skipro-wizard-inline.component';
 import { SkiProClientePerfilInlineComponent } from './components/skipro-cliente-perfil-inline/skipro-cliente-perfil-inline.component';
+import { SkiProReservaDetallesComponent } from './components/skipro-reserva-detalles/skipro-reserva-detalles.component';
+import { SkiProCancelarReservaComponent } from './components/skipro-cancelar-reserva/skipro-cancelar-reserva.component';
 
 // Services
 import { SkiProMockDataService } from './services/mock/skipro-mock-data.service';
@@ -40,7 +42,9 @@ import { MockDataService } from './services/mock/mock-data.service';
     SkiProWizardComponent,
     SkiProClientePerfilComponent,
     SkiProWizardInlineComponent,
-    SkiProClientePerfilInlineComponent
+    SkiProClientePerfilInlineComponent,
+    SkiProReservaDetallesComponent,
+    SkiProCancelarReservaComponent
   ],
   imports: [
     CommonModule,


### PR DESCRIPTION
## Summary
- add components for reservation details and cancel confirmation
- navigate to wizard in edit mode from booking list
- allow preselecting client when opening wizard from profile
- include new components in SkiPro module and mock service

## Testing
- `npm install`
- `npm test` *(fails: FATAL ERROR Reached heap limit)*

------
https://chatgpt.com/codex/tasks/task_e_68835429d89083208a048ae7ff12744e