### PR TITLE
Implement service factories for booking v3

### DIFF
--- a/src/app/bookings-v3/bookings-v3.module.ts
+++ b/src/app/bookings-v3/bookings-v3.module.ts
@@ -44,13 +44,7 @@ import { ClientSelectionStepComponent } from './wizard/steps/client-selection/cl
 
 // Services Mock (para desarrollo)
 import { MockDataService } from './services/mock/mock-data.service';
-import { SmartBookingServiceMock } from './services/mock/smart-booking.service.mock';
-import { SmartClientServiceMock } from './services/mock/smart-client.service.mock';
-import { ClientAnalyticsServiceMock } from './services/mock/client-analytics.service.mock';
-import { ActivitySelectionServiceMock } from './services/mock/activity-selection.service.mock';
-import { ScheduleSelectionServiceMock } from './services/mock/schedule-selection.service.mock';
-import { ParticipantDetailsServiceMock } from './services/mock/participant-details.service.mock';
-import { PricingConfirmationServiceMock } from './services/mock/pricing-confirmation.service.mock';
+import { BOOKING_V3_PROVIDERS } from './services/service.factory';
 
 @NgModule({
   declarations: [
@@ -99,15 +93,8 @@ import { PricingConfirmationServiceMock } from './services/mock/pricing-confirma
     BookingsV3RoutingModule
   ],
   providers: [
-    // Mock Services para desarrollo
     MockDataService,
-    SmartBookingServiceMock,
-    SmartClientServiceMock,
-    ClientAnalyticsServiceMock,
-    ActivitySelectionServiceMock,
-    ScheduleSelectionServiceMock,
-    ParticipantDetailsServiceMock,
-    PricingConfirmationServiceMock
+    ...BOOKING_V3_PROVIDERS
   ]
 })
 export class BookingsV3Module { }

--- a/src/app/bookings-v3/services/activity-selection.service.ts
+++ b/src/app/bookings-v3/services/activity-selection.service.ts
@@ -1,0 +1,6 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class ActivitySelectionService {
+  // TODO: implement real activity selection logic
+}

--- a/src/app/bookings-v3/services/client-analytics.service.ts
+++ b/src/app/bookings-v3/services/client-analytics.service.ts
@@ -1,0 +1,6 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class ClientAnalyticsService {
+  // TODO: implement real analytics integration
+}

--- a/src/app/bookings-v3/services/participant-details.service.ts
+++ b/src/app/bookings-v3/services/participant-details.service.ts
@@ -1,0 +1,6 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class ParticipantDetailsService {
+  // TODO: implement participant validation logic
+}

--- a/src/app/bookings-v3/services/pricing-confirmation.service.ts
+++ b/src/app/bookings-v3/services/pricing-confirmation.service.ts
@@ -1,0 +1,6 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class PricingConfirmationService {
+  // TODO: implement real pricing logic
+}

--- a/src/app/bookings-v3/services/schedule-selection.service.ts
+++ b/src/app/bookings-v3/services/schedule-selection.service.ts
@@ -1,0 +1,6 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class ScheduleSelectionService {
+  // TODO: implement real schedule selection logic
+}

--- a/src/app/bookings-v3/services/service.factory.ts
+++ b/src/app/bookings-v3/services/service.factory.ts
@@ -2,9 +2,28 @@ import { inject, InjectionToken } from '@angular/core';
 import { environment } from '../../../environments/environment';
 
 import { SmartBookingService } from './smart-booking.service';
+import { SmartClientService } from './smart-client.service';
+import { ClientAnalyticsService } from './client-analytics.service';
+import { ActivitySelectionService } from './activity-selection.service';
+import { ScheduleSelectionService } from './schedule-selection.service';
+import { ParticipantDetailsService } from './participant-details.service';
+import { PricingConfirmationService } from './pricing-confirmation.service';
+
 import { SmartBookingServiceMock } from './mock/smart-booking.service.mock';
+import { SmartClientServiceMock } from './mock/smart-client.service.mock';
+import { ClientAnalyticsServiceMock } from './mock/client-analytics.service.mock';
+import { ActivitySelectionServiceMock } from './mock/activity-selection.service.mock';
+import { ScheduleSelectionServiceMock } from './mock/schedule-selection.service.mock';
+import { ParticipantDetailsServiceMock } from './mock/participant-details.service.mock';
+import { PricingConfirmationServiceMock } from './mock/pricing-confirmation.service.mock';
 
 export const SMART_BOOKING_SERVICE = new InjectionToken<SmartBookingService>('SmartBookingService');
+export const SMART_CLIENT_SERVICE = new InjectionToken<SmartClientService>('SmartClientService');
+export const CLIENT_ANALYTICS_SERVICE = new InjectionToken<ClientAnalyticsService>('ClientAnalyticsService');
+export const ACTIVITY_SELECTION_SERVICE = new InjectionToken<ActivitySelectionService>('ActivitySelectionService');
+export const SCHEDULE_SELECTION_SERVICE = new InjectionToken<ScheduleSelectionService>('ScheduleSelectionService');
+export const PARTICIPANT_DETAILS_SERVICE = new InjectionToken<ParticipantDetailsService>('ParticipantDetailsService');
+export const PRICING_CONFIRMATION_SERVICE = new InjectionToken<PricingConfirmationService>('PricingConfirmationService');
 
 export function smartBookingServiceFactory() {
   return environment.useRealServices ?
@@ -12,6 +31,48 @@ export function smartBookingServiceFactory() {
     inject(SmartBookingServiceMock);
 }
 
+export function smartClientServiceFactory() {
+  return environment.useRealServices ?
+    inject(SmartClientService) :
+    inject(SmartClientServiceMock);
+}
+
+export function clientAnalyticsServiceFactory() {
+  return environment.useRealServices ?
+    inject(ClientAnalyticsService) :
+    inject(ClientAnalyticsServiceMock);
+}
+
+export function activitySelectionServiceFactory() {
+  return environment.useRealServices ?
+    inject(ActivitySelectionService) :
+    inject(ActivitySelectionServiceMock);
+}
+
+export function scheduleSelectionServiceFactory() {
+  return environment.useRealServices ?
+    inject(ScheduleSelectionService) :
+    inject(ScheduleSelectionServiceMock);
+}
+
+export function participantDetailsServiceFactory() {
+  return environment.useRealServices ?
+    inject(ParticipantDetailsService) :
+    inject(ParticipantDetailsServiceMock);
+}
+
+export function pricingConfirmationServiceFactory() {
+  return environment.useRealServices ?
+    inject(PricingConfirmationService) :
+    inject(PricingConfirmationServiceMock);
+}
+
 export const BOOKING_V3_PROVIDERS = [
-  { provide: SMART_BOOKING_SERVICE, useFactory: smartBookingServiceFactory }
+  { provide: SMART_BOOKING_SERVICE, useFactory: smartBookingServiceFactory },
+  { provide: SMART_CLIENT_SERVICE, useFactory: smartClientServiceFactory },
+  { provide: CLIENT_ANALYTICS_SERVICE, useFactory: clientAnalyticsServiceFactory },
+  { provide: ACTIVITY_SELECTION_SERVICE, useFactory: activitySelectionServiceFactory },
+  { provide: SCHEDULE_SELECTION_SERVICE, useFactory: scheduleSelectionServiceFactory },
+  { provide: PARTICIPANT_DETAILS_SERVICE, useFactory: participantDetailsServiceFactory },
+  { provide: PRICING_CONFIRMATION_SERVICE, useFactory: pricingConfirmationServiceFactory }
 ];

--- a/src/app/bookings-v3/services/smart-client.service.ts
+++ b/src/app/bookings-v3/services/smart-client.service.ts
@@ -1,0 +1,6 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class SmartClientService {
+  // TODO: implement real client lookup logic
+}


### PR DESCRIPTION
## Summary
- add stub service implementations for booking-v3 real services
- implement `BOOKING_V3_PROVIDERS` in `service.factory.ts`
- use new provider array in `BookingsV3Module`

## Testing
- `npm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_688359a27420832082026ddaaeadf106