### PR TITLE
Add styles for new booking components

### DIFF
--- a/src/app/bookings-v3/wizard/booking-wizard.component.scss
+++ b/src/app/bookings-v3/wizard/booking-wizard.component.scss
@@ -1,9 +1,10 @@
 // ============= VARIABLES Y MIXINS =============
 :root {
-  --wizard-primary: #6B46C1;
-  --wizard-primary-light: #8B5CF6;
-  --wizard-primary-dark: #553C9A;
-  --wizard-secondary: #10B981;
+  // Colors tuned to match design references in screenshots
+  --wizard-primary: #5e49db;
+  --wizard-primary-light: #7a6bf3;
+  --wizard-primary-dark: #4b39c1;
+  --wizard-secondary: #5996d3;
   --wizard-accent: #F59E0B;
   --wizard-error: #EF4444;
   --wizard-warning: #F59E0B;
@@ -592,6 +593,11 @@
 }
 
 // ============= RESPONSIVE =============
+@media (max-width: 1280px) {
+  .wizard-container {
+    max-width: 100%;
+  }
+}
 @media (max-width: 768px) {
   .booking-wizard-overlay {
     padding: 10px;

--- a/src/app/pages/bookings-dashboard/bookings-dashboard.component.html
+++ b/src/app/pages/bookings-dashboard/bookings-dashboard.component.html
@@ -63,6 +63,7 @@
       </button>
     </form>
 
+    <div class="table-wrapper">
     <table mat-table [dataSource]="bookings" class="bookings-table">
       <ng-container matColumnDef="id">
         <th mat-header-cell *matHeaderCellDef> ID </th>
@@ -115,6 +116,7 @@
       <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
       <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
     </table>
+    </div>
 
   </vex-page-layout-content>
 </vex-page-layout>

--- a/src/app/pages/bookings-dashboard/bookings-dashboard.component.scss
+++ b/src/app/pages/bookings-dashboard/bookings-dashboard.component.scss
@@ -7,7 +7,7 @@
   mat-card {
     text-align: center;
     padding: 12px;
-    background: #1e1e1e;
+    background: linear-gradient(135deg, #5e49db, #8478d1);
     color: #fff;
   }
 }
@@ -22,6 +22,16 @@
 
 .bookings-table {
   width: 100%;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+@media (max-width: 768px) {
+  .bookings-table {
+    min-width: 600px;
+  }
 }
 
 .actions {


### PR DESCRIPTION
## Summary
- tweak wizard color palette with screenshot hues
- add responsive max-width for wizard overlay
- improve bookings dashboard layout colors
- make bookings table scrollable on small screens

## Testing
- `npm install` *(fails: npm warnings and environment out-of-memory during tests)*

------
https://chatgpt.com/codex/tasks/task_e_68838cb4e3408320ae27a1ea8f0148f7