### PR TITLE
Add v5 global styles

### DIFF
--- a/src/app/v5/layout/v5-layout.component.html
+++ b/src/app/v5/layout/v5-layout.component.html
@@ -1,4 +1,4 @@
-<mat-sidenav-container class="v5-container">
+<mat-sidenav-container class="v5-container v5-layout">
   <mat-sidenav #sidenav mode="side" opened class="v5-sidenav">
     <app-sidebar (navigate)="sidenav.close()"></app-sidebar>
   </mat-sidenav>

--- a/src/app/v5/layout/v5-layout.component.scss
+++ b/src/app/v5/layout/v5-layout.component.scss
@@ -1,7 +1,9 @@
+@import "../../../styles/v5/variables";
+
 .v5-container {
   height: 100vh;
 }
 
 .v5-content {
-  padding: 16px;
+  padding: $v5-spacing-md;
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -7,6 +7,9 @@
 // Nuevo sistema de diseño Boukii
 @import "./styles/dashboard-theme";
 @import "./styles/sidenav-enhanced";
+// Estilos globales para la versión 5
+@import "./styles/v5/variables";
+@import "./styles/v5/base";
 
 @font-face {
   font-family: "Dinamit";

--- a/src/styles/v5/_base.scss
+++ b/src/styles/v5/_base.scss
@@ -1,0 +1,66 @@
+@import './variables';
+
+.v5-layout {
+  font-family: $v5-font-family;
+  background: $v5-bg;
+  color: $v5-text;
+  min-height: 100vh;
+}
+
+.v5-content {
+  padding: $v5-spacing-md;
+}
+
+.v5-button {
+  background-color: $v5-primary;
+  border: none;
+  border-radius: 4px;
+  padding: $v5-spacing-sm $v5-spacing-md;
+  color: #fff;
+  cursor: pointer;
+  font-weight: 500;
+  transition: background-color 0.2s ease;
+
+  &:hover {
+    background-color: darken($v5-primary, 5%);
+  }
+
+  &.accent {
+    background-color: $v5-accent;
+  }
+
+  &.warn {
+    background-color: $v5-warn;
+  }
+}
+
+.v5-input {
+  display: block;
+  width: 100%;
+  padding: $v5-spacing-sm $v5-spacing-md;
+  border: 1px solid $v5-surface;
+  border-radius: 4px;
+  background-color: #fff;
+
+  &:focus {
+    outline: none;
+    border-color: $v5-primary;
+  }
+}
+
+.v5-table {
+  width: 100%;
+  border-collapse: collapse;
+  background-color: #fff;
+
+  th, td {
+    padding: $v5-spacing-sm $v5-spacing-md;
+    border-bottom: 1px solid $v5-surface;
+    text-align: left;
+  }
+
+  th {
+    background-color: $v5-surface;
+    font-weight: 600;
+  }
+}

--- a/src/styles/v5/_variables.scss
+++ b/src/styles/v5/_variables.scss
@@ -1,0 +1,29 @@
+$v5-primary: #5A3FFF;
+$v5-accent: #3B82F6;
+$v5-warn: #EF4444;
+$v5-bg: #ffffff;
+$v5-surface: #f3f4f6;
+$v5-text: #1f2937;
+
+$v5-spacing-xs: 4px;
+$v5-spacing-sm: 8px;
+$v5-spacing-md: 16px;
+$v5-spacing-lg: 24px;
+$v5-spacing-xl: 32px;
+
+$v5-font-family: 'DM Sans', sans-serif;
+
+:root {
+  --v5-primary: #{$v5-primary};
+  --v5-accent: #{$v5-accent};
+  --v5-warn: #{$v5-warn};
+  --v5-bg: #{$v5-bg};
+  --v5-surface: #{$v5-surface};
+  --v5-text: #{$v5-text};
+  --v5-spacing-xs: #{$v5-spacing-xs};
+  --v5-spacing-sm: #{$v5-spacing-sm};
+  --v5-spacing-md: #{$v5-spacing-md};
+  --v5-spacing-lg: #{$v5-spacing-lg};
+  --v5-spacing-xl: #{$v5-spacing-xl};
+  --v5-font-family: #{$v5-font-family};
+}


### PR DESCRIPTION
## Summary
- create SCSS variables and base styles for v5 layout
- import v5 styles globally
- integrate classes into V5LayoutComponent

## Testing
- `npm test --silent --no-progress` *(fails: ChromeHeadless missing)*

------
https://chatgpt.com/codex/tasks/task_e_6887dfc9eea88320aafee4e0644c975e