### PR TITLE
Implement auth + season guards for v5

### DIFF
--- a/src/app/v5/core/guards/auth-v5.guard.ts
+++ b/src/app/v5/core/guards/auth-v5.guard.ts
@@ -7,8 +7,7 @@ export class AuthV5Guard implements CanActivate {
   constructor(private authService: AuthV5Service, private router: Router) {}
 
   canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean {
-    // TODO: real authentication logic
-    const isLogged = true;
+    const isLogged = this.authService.isAuthenticated();
     if (!isLogged) {
       this.router.navigate(['/login']);
       return false;

--- a/src/app/v5/core/guards/season-context.guard.ts
+++ b/src/app/v5/core/guards/season-context.guard.ts
@@ -7,10 +7,10 @@ export class SeasonContextGuard implements CanActivate {
   constructor(private seasonContext: SeasonContextService, private router: Router) {}
 
   canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean {
-    // TODO: ensure season is selected
-    const seasonSelected = true;
+    const seasonSelected = !!this.seasonContext.getCurrentSeason();
     if (!seasonSelected) {
-      this.router.navigate(['/seasons']);
+      this.seasonContext.promptSeasonSelection();
+      this.router.navigate(['/v5/seasons']);
       return false;
     }
     return true;

--- a/src/app/v5/v5-routing.module.ts
+++ b/src/app/v5/v5-routing.module.ts
@@ -2,11 +2,14 @@ import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { V5LayoutComponent } from './layout/v5-layout.component';
 import { WelcomeComponent } from './pages/welcome/welcome.component';
+import { AuthV5Guard } from './core/guards/auth-v5.guard';
+import { SeasonContextGuard } from './core/guards/season-context.guard';
 
 const routes: Routes = [
   {
     path: '',
     component: V5LayoutComponent,
+    canActivate: [AuthV5Guard],
     children: [
       { path: '', component: WelcomeComponent },
       {
@@ -16,6 +19,7 @@ const routes: Routes = [
       },
       {
         path: 'schools',
+        canActivate: [SeasonContextGuard],
         loadChildren: () =>
           import('./features/schools/schools.module').then(m => m.SchoolsModule)
       }

--- a/src/app/v5/v5.module.ts
+++ b/src/app/v5/v5.module.ts
@@ -21,8 +21,6 @@ import { SeasonContextService } from './core/services/season-context.service';
 import { AuthV5Service } from './core/services/auth-v5.service';
 import { NotificationService } from './core/services/notification.service';
 import { LoadingService } from './core/services/loading.service';
-import { SeasonsModule } from './features/seasons/seasons.module';
-import { SchoolsModule } from './features/schools/schools.module';
 
 @NgModule({
   declarations: [
@@ -41,9 +39,7 @@ import { SchoolsModule } from './features/schools/schools.module';
     MatButtonModule,
     StoreModule.forRoot({}),
     EffectsModule.forRoot([]),
-    V5RoutingModule,
-    SeasonsModule,
-    SchoolsModule
+    V5RoutingModule
   ],
   providers: [
     ApiV5Service,


### PR DESCRIPTION
## Summary
- enforce authentication check in AuthV5Guard
- require season selection in SeasonContextGuard
- guard v5 routes and lazy load feature modules
- remove eagerly loaded feature modules from V5Module

## Testing
- `npm install`
- `npm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_6888d255b60c83208a214504b65f8ce3