### PR TITLE
ci: configure docs sync workflow

### DIFF
--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -1,0 +1,21 @@
+name: Sync Docs
+
+on:
+  push:
+    paths:
+      - 'docs/shared/**'
+      - 'docs/frontend/**'
+
+jobs:
+  sync:
+    if: ${{ !contains(github.event.head_commit.message, 'docs-sync:') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Sync shared docs
+        uses: some-org/sync-directory-action@v1
+        with:
+          source-directory: 'docs/shared'
+          destination-directory: 'docs/shared'


### PR DESCRIPTION
## Summary
- add docs sync workflow limited to shared and frontend docs
- avoid sync loops by skipping docs-sync commits
- simplify sync step with explicit source/destination directories

## Testing
- `npm test` *(fails: could not find a package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689da6d4244883209d19af48398a6b34