### PR TITLE
chore: use dynamic payment provider reference

### DIFF
--- a/src/app/pages/bookings/booking-detail-modal/booking-detail-modal.component.html
+++ b/src/app/pages/bookings/booking-detail-modal/booking-detail-modal.component.html
@@ -730,8 +730,7 @@
                 <button mat-raised-button color="accent" class="square-button"
                   (click)="selectedSubButton='3'; defaults.payment_method_id = 2"
                   [class.selected]="selectedSubButton==='3'"
-                  [disabled]="booking.payrexx_reference === null">Boukii
-                  Pay</button>
+                  [disabled]="booking[schoolService.getPaymentProvider() === 'payyo' ? 'payyo_reference' : 'payrexx_reference'] === null">{{ schoolService.getPaymentProvider() === 'payyo' ? 'Payyo' : 'Boukii Pay' }}</button>
               </div>
               <mat-divider
                 *ngIf="selectedSubButton==='1' || selectedSubButton==='2'"

--- a/src/app/pages/bookings/booking-detail-modal/booking-detail-modal.component.ts
+++ b/src/app/pages/bookings/booking-detail-modal/booking-detail-modal.component.ts
@@ -209,7 +209,7 @@ export class BookingDetailModalComponent implements OnInit {
   degreesClient:any[]=[];
 
   constructor(private bookingService: BookingService, private dialog: MatDialog, private crudService: ApiCrudService, private calendarService: CalendarService,
-    private snackbar: MatSnackBar, public translateService: TranslateService, private schoolService: SchoolService, private router: Router,
+    private snackbar: MatSnackBar, public translateService: TranslateService, public schoolService: SchoolService, private router: Router,
     @Inject(MAT_DIALOG_DATA) public incData: any, private dialogRef: MatDialogRef<any>,) {
 
                 this.minDate = new Date(); // Establecer la fecha mínima como la fecha actual

--- a/src/app/pages/bookings/cancel-booking/cancel-booking.component.html
+++ b/src/app/pages/bookings/cancel-booking/cancel-booking.component.html
@@ -46,12 +46,12 @@
           <mat-dialog-content class="flex flex-col" *ngIf="!loading">
             <div style="width: 100%;">
               <p
-                *ngIf="defaults.booking.payrexx_reference !== null">{{'bookings_page.cancelations.refund_boukiipay_text'
+                *ngIf="defaults.booking[schoolService.getPaymentProvider() === 'payyo' ? 'payyo_reference' : 'payrexx_reference'] !== null">{{'bookings_page.cancelations.refund_boukiipay_text'
                 | translate }}: <span
                   style="color:#fe3085">{{defaults.itemPrice}}
                   {{defaults.booking.currency}}</span></p>
               <p
-                *ngIf="defaults.booking.payrexx_reference === null">{{'bookings_page.cancelations.refund_no_boukiipay_text'
+                *ngIf="defaults.booking[schoolService.getPaymentProvider() === 'payyo' ? 'payyo_reference' : 'payrexx_reference'] === null">{{'bookings_page.cancelations.refund_no_boukiipay_text'
                 | translate }}</p>
 
             </div>
@@ -59,7 +59,7 @@
             <mat-divider></mat-divider>
 
             <mat-dialog-actions align="end"
-              *ngIf="!loading && defaults.booking.payrexx_reference !== null">
+              *ngIf="!loading && defaults.booking[schoolService.getPaymentProvider() === 'payyo' ? 'payyo_reference' : 'payrexx_reference'] !== null">
               <button color="primary" mat-flat-button
                 (click)="closeAndSave('boukii_pay')">{{'confirm' |
                 translate}}</button>

--- a/src/app/pages/bookings/cancel-partial-booking/cancel-partial-booking.component.html
+++ b/src/app/pages/bookings/cancel-partial-booking/cancel-partial-booking.component.html
@@ -32,11 +32,11 @@
         <mat-tab [label]="schoolService.getPaymentProvider() === 'payyo' ? 'Payyo' : 'Boukii Pay'">
           <mat-dialog-content class="flex flex-col" *ngIf="!loading">
             <div style="width: 100%;">
-              <p *ngIf="defaults.booking.payrexx_reference !== null">{{'bookings_page.cancelations.refund_boukiipay_text' | translate }}: <span style="color:#fe3085">{{defaults.itemPrice}} {{defaults.booking.currency}}</span></p>
-              <p *ngIf="defaults.booking.payrexx_reference === null">{{'bookings_page.cancelations.refund_no_boukiipay_text' | translate }}: <span style="color:#fe3085">{{defaults.itemPrice}} {{defaults.booking.currency}}</span></p>
+              <p *ngIf="defaults.booking[schoolService.getPaymentProvider() === 'payyo' ? 'payyo_reference' : 'payrexx_reference'] !== null">{{'bookings_page.cancelations.refund_boukiipay_text' | translate }}: <span style="color:#fe3085">{{defaults.itemPrice}} {{defaults.booking.currency}}</span></p>
+              <p *ngIf="defaults.booking[schoolService.getPaymentProvider() === 'payyo' ? 'payyo_reference' : 'payrexx_reference'] === null">{{'bookings_page.cancelations.refund_no_boukiipay_text' | translate }}: <span style="color:#fe3085">{{defaults.itemPrice}} {{defaults.booking.currency}}</span></p>
             </div>
             <mat-divider></mat-divider>
-            <mat-dialog-actions align="end" *ngIf="!loading && defaults.booking.payrexx_reference !== null">
+            <mat-dialog-actions align="end" *ngIf="!loading && defaults.booking[schoolService.getPaymentProvider() === 'payyo' ? 'payyo_reference' : 'payrexx_reference'] !== null">
               <button color="primary" mat-flat-button (click)="closeAndSave('boukii_pay')">{{'confirm' | translate}}</button>
               <button color="primary" mat-flat-button [mat-dialog-close]="false">{{'no' | translate}}</button>
             </mat-dialog-actions>

--- a/src/app/pages/bookings/refund-booking/refund-booking.component.html
+++ b/src/app/pages/bookings/refund-booking/refund-booking.component.html
@@ -38,14 +38,14 @@
 
           <mat-dialog-content class="flex flex-col" *ngIf="!loading">
             <div style="width: 100%;">
-              <p *ngIf="defaults.booking.payrexx_reference !== null">{{'bookings_page.cancelations.refund_boukiipay_text' | translate }}: <span style="color:#fe3085">{{defaults.itemPrice}} {{defaults.booking.currency}}</span></p>
-              <p *ngIf="defaults.booking.payrexx_reference === null">{{'bookings_page.cancelations.refund_no_boukiipay_text' | translate }}</p>
+              <p *ngIf="defaults.booking[schoolService.getPaymentProvider() === 'payyo' ? 'payyo_reference' : 'payrexx_reference'] !== null">{{'bookings_page.cancelations.refund_boukiipay_text' | translate }}: <span style="color:#fe3085">{{defaults.itemPrice}} {{defaults.booking.currency}}</span></p>
+              <p *ngIf="defaults.booking[schoolService.getPaymentProvider() === 'payyo' ? 'payyo_reference' : 'payrexx_reference'] === null">{{'bookings_page.cancelations.refund_no_boukiipay_text' | translate }}</p>
 
             </div>
 
             <mat-divider></mat-divider>
 
-            <mat-dialog-actions align="end" *ngIf="!loading && defaults.booking.payrexx_reference !== null">
+            <mat-dialog-actions align="end" *ngIf="!loading && defaults.booking[schoolService.getPaymentProvider() === 'payyo' ? 'payyo_reference' : 'payrexx_reference'] !== null">
               <button color="primary" mat-flat-button (click)="closeAndSave('boukii_pay')">{{'confirm' | translate}}</button>
               <button color="primary" mat-flat-button [mat-dialog-close]="false">{{'no' | translate}}</button>
             </mat-dialog-actions>


### PR DESCRIPTION
## Summary
- Use provider-based payment reference checks in booking cancellation templates
- Display active payment provider name on booking detail modal button
- Expose SchoolService to booking detail modal template

## Testing
- `npm test` *(fails: Reached heap limit Allocation failed - JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68b0d61d8a588320a6384c2c1913d565