### PR TITLE
feat: add only_weekends translation

### DIFF
--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -854,6 +854,7 @@
   "export_data": "Daten exportieren",
   "filters": "Filter",
   "weekends_only": "Nur am Wochenende",
+  "only_weekends": "Nur an Wochenenden",
   "revenue_trend": "Einnahmentrend",
   "payment_methods": "Zahlungsmethoden",
   "course_type_performance": "Leistung nach Kurstyp",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -853,6 +853,7 @@
   "export_data": "Export Data",
   "filters": "Filters",
   "weekends_only": "Weekends Only",
+  "only_weekends": "Only weekends",
   "revenue_trend": "Revenue Trend",
   "payment_methods": "Payment Methods",
   "course_type_performance": "Course Type Performance",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -861,6 +861,7 @@
   "export_data": "Exportar Datos",
   "filters": "Filtros",
   "weekends_only": "Solo Fines de Semana",
+  "only_weekends": "Solo fines de semana",
   "revenue_trend": "Tendencia de Ingresos",
   "payment_methods": "Métodos de Pago",
   "course_type_performance": "Rendimiento por Tipo de Curso",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -853,6 +853,7 @@
   "export_data": "Exporter les Données",
   "filters": "Filtres",
   "weekends_only": "Week-ends Uniquement",
+  "only_weekends": "Uniquement les week-ends",
   "revenue_trend": "Tendance des Revenus",
   "payment_methods": "Méthodes de Paiement",
   "course_type_performance": "Performance par Type de Cours",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -853,6 +853,7 @@
   "export_data": "Esporta Dati",
   "filters": "Filtri",
   "weekends_only": "Solo Fine Settimana",
+  "only_weekends": "Solo fine settimana",
   "revenue_trend": "Andamento dei Ricavi",
   "payment_methods": "Metodi di Pagamento",
   "course_type_performance": "Performance per Tipo di Corso",


### PR DESCRIPTION
## Summary
- add `only_weekends` translation across locales
- ensure analytics filter uses new key

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: Generating browser application bundles...)*

------
https://chatgpt.com/codex/tasks/task_e_68b7f28563508320a3d20e1a12e216ed