### PR TITLE
Localize weekend filter text

### DIFF
--- a/src/app/pages/analytics-v2/filters/filters.component.html
+++ b/src/app/pages/analytics-v2/filters/filters.component.html
@@ -184,7 +184,7 @@
       <div class="checkbox-section">
         <mat-checkbox formControlName="onlyWeekends" class="weekend-checkbox">
           <mat-icon>weekend</mat-icon>
-          Solo fines de semana
+          {{ 'only_weekends' | translate }}
         </mat-checkbox>
       </div>
 


### PR DESCRIPTION
## Summary
- Localize "Solo fines de semana" using translate pipe in analytics filters

## Testing
- `node --max-old-space-size=4096 node_modules/@angular/cli/bin/ng test --watch=false --browsers=ChromeHeadless` *(fails: module resolution errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b82222e38083208a2ce2014dcc7d95